### PR TITLE
Add tooltips to chunks in chunk view modules

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -19,6 +19,7 @@ function load(stats) {
 		module.dependencies = [];
 	});
 	var mapChunks = {};
+	var dependencySizeCache = {};
 	stats.chunks.forEach(function(chunk) {
 		mapChunks[chunk.id] = chunk;
 		chunk.children = [];
@@ -61,8 +62,14 @@ function load(stats) {
 			if(!m) return;
 			origin.moduleUid = m.uid;
 		});
+		chunk.modules.forEach(function(module) {
+			var m = mapModulesIdent["$"+module.identifier], s;
+			if(!m) return;
+			module.recursiveSize = recursiveSize(m, mapModules, dependencySizeCache);
+		});
 	});
 	stats.modules.forEach(function(module) {
+		module.recursiveSize = recursiveSize(module, mapModules, dependencySizeCache);
 		module.dependencies.sort(function(a, b) {
 			if(!a.loc && !b.loc) return 0;
 			if(!a.loc) return 1;
@@ -113,4 +120,35 @@ function categorize(number) {
 		number = Math.floor(number / 10);
 	} while(number > 0)
 	return "";
+}
+
+
+// Calculate the recursive dependency size for a module
+// This function has the side effect of updating a passed cache object
+function recursiveSize(m, moduleMap, dependencySizeCache) {
+	var depSize,
+	cachedDepSize = dependencySizeCache[m.uid];
+	if (cachedDepSize) {
+		depSize = cachedDepSize;
+	} else {
+		depSize = calculateDependencySize(m, {}, moduleMap);
+		dependencySizeCache[m.uid] = depSize;
+	}
+	return m.size + depSize;
+}
+
+function calculateDependencySize(m, traversed, moduleMap) {
+	return m.dependencies.reduce(function (depSize, dep) {
+		var depMod = moduleMap[dep.moduleId];
+		if (!traversed[dep.moduleUid]) {
+			// Mark this module as already included in the calculation
+			// to avoid double-counting or circular dependencies
+			traversed[dep.moduleUid] = true;
+			// Add the size of this dependency...
+			depSize  += depMod.size;
+			// ...and all of its dependencies
+			depSize += calculateDependencySize(depMod, traversed, moduleMap);
+		}
+		return depSize;
+	}, 0);
 }

--- a/app/pages/chunk/chunk.jade
+++ b/app/pages/chunk/chunk.jade
@@ -74,8 +74,8 @@
 					tr
 						th id
 						th name
-						th size
-						th recursive size
+						th: a#size(href='#') size
+						th: a#recursive-size(href='#') recursive size
 						th chunks
 						th flags
 				tbody

--- a/app/pages/chunk/chunk.jade
+++ b/app/pages/chunk/chunk.jade
@@ -75,6 +75,7 @@
 						th id
 						th name
 						th size
+						th recursive size
 						th chunks
 						th flags
 				tbody
@@ -87,6 +88,7 @@
 									span.btn.btn-success= module.id
 							td: pre: code= module.name.split("!").join("\n")
 							td= require("../../formatSize")(module.size)
+							td= require("../../formatSize")(module.recursiveSize)
 							td
 								each chunk in module.chunks
 									a.btn.btn-info(href="#chunk/#{chunk}")= chunk

--- a/app/pages/chunk/chunk.jade
+++ b/app/pages/chunk/chunk.jade
@@ -91,7 +91,7 @@
 							td= require("../../formatSize")(module.recursiveSize)
 							td
 								each chunk in module.chunks
-									a.btn.btn-info(href="#chunk/#{chunk}")= chunk
+									a.btn.btn-info(href="#chunk/#{chunk}", title="#{mapChunks[chunk].names.join(',')}")= chunk
 									= " "
 							td
 								if module.built

--- a/app/pages/chunk/page.js
+++ b/app/pages/chunk/page.js
@@ -8,7 +8,8 @@ module.exports = function(id) {
 	$(".page").html(require("./chunk.jade")({
 		stats: app.stats,
 		id: id,
-		chunk: app.mapChunks[id]
+		chunk: app.mapChunks[id],
+		mapChunks: app.mapChunks
 	}));
 	modulesGraph.show();
 	modulesGraph.setActiveChunk(id);

--- a/app/pages/chunk/page.js
+++ b/app/pages/chunk/page.js
@@ -1,5 +1,6 @@
 var app = require("../../app");
 var modulesGraph = require("../../graphs/modules");
+var sortTable = require("../../sortTable");
 
 module.exports = function(id) {
 	id = parseInt(id, 10);
@@ -11,6 +12,14 @@ module.exports = function(id) {
 	}));
 	modulesGraph.show();
 	modulesGraph.setActiveChunk(id);
+	$('#size').click(function(e){
+		e.preventDefault();
+		sortTable(3);
+	});
+	$('#recursive-size').click(function(e){
+		e.preventDefault();
+		sortTable(4);
+	});
 	return function() {
 		modulesGraph.hide();
 	}

--- a/app/pages/module/module.jade
+++ b/app/pages/module/module.jade
@@ -4,7 +4,7 @@
 			table(width="100%"): tbody: tr
 				td: a.btn.btn-success.disabled(href="#module/#{module.uid}")= module.id
 				td: pre: code= module.name.split("!").join("\n")
-		.col-md-3: .well
+		.col-md-2: .well
 			h4 time
 			if module.time
 				code= module.time + "ms"
@@ -13,9 +13,12 @@
 					code= module.timestamp + "ms"
 			else
 				| Compile with <code>--profile</code>.
-		.col-md-3: .well
+		.col-md-2: .well
 			h4 size
 			= require("../../formatSize")(module.size)
+		.col-md-2: .well
+			h4 recursive size
+			= require("../../formatSize")(module.recursiveSize)
 	.row
 		.col-md-3: .well
 			h4 flags

--- a/app/pages/modules/modules.jade
+++ b/app/pages/modules/modules.jade
@@ -4,6 +4,7 @@ table.table.table-condensed
 			th id
 			th name
 			th size
+			th recursive size
 			th chunks
 			th flags
 	tbody
@@ -16,6 +17,7 @@ table.table.table-condensed
 						span.btn.btn-success= module.id
 				td: pre: code= module.name.split("!").join("\n")
 				td= require("../../formatSize")(module.size)
+				td= require("../../formatSize")(module.recursiveSize)
 				td
 					each chunk in module.chunks
 						a.btn.btn-info(href="#chunk/#{chunk}")= chunk

--- a/app/sortTable.js
+++ b/app/sortTable.js
@@ -1,0 +1,41 @@
+module.exports = function sortTable(colNumber) {
+	var table = document.querySelectorAll('tbody')[1];
+	var	sizeKey = 'data-size-' + colNumber;
+	var	sortKey = 'data-sort-desc-' + colNumber;
+
+	// Sort table desc initially, then alternate
+	if (!table.hasAttribute(sortKey)) {
+		table.setAttribute(sortKey, 1);
+	}
+	var sortDesc = parseInt(table.getAttribute(sortKey), 0);
+	if (sortDesc) {
+		table.setAttribute(sortKey, 0);
+	} else {
+		table.setAttribute(sortKey, 1);
+	}
+
+	Array.prototype.slice.apply(table.querySelectorAll('tr')).forEach(function (el) {
+		var size = el.querySelector('td:nth-of-type(' + colNumber + ')').innerHTML;
+		var num = origNum = parseInt(size,0);
+		if (size.indexOf('KiB') > -1) {
+			num = num * 1024;
+		} else if (size.indexOf('MiB') > -1) {
+			num = num * 1024 * 1024;
+		}
+		el.setAttribute(sizeKey, num);
+	});
+
+	var rows = Array.prototype.slice.apply(table.querySelectorAll('tr'));
+	rows.forEach(function (row) {
+		var currentSize = parseInt(row.getAttribute(sizeKey), 0);
+		var moved = false;
+		Array.prototype.slice.apply(table.querySelectorAll('tr')).forEach(function (irow) {
+			var irowSize = parseInt(irow.getAttribute(sizeKey), 0);
+			var insertBefore = sortDesc ? currentSize >= irowSize : currentSize <= irowSize; 
+			if (!moved && insertBefore) {
+				irow.parentNode.insertBefore(row, insertBefore ? irow : irow.nextSibling);
+				moved = true;
+			}
+		});
+	});
+}


### PR DESCRIPTION
Another quick hack we can use to help analyze webpack modules/chunks. Eventually this should be abstracted and used everywhere in the tool, but I don't think that's the best use of time right now. I've created a trello ticket to remember to do this:

https://trello.com/c/lRRCalxn/64-abstract-tooltips-for-chunks-in-the-analyse-tool

NOTE: I'm just going to merge this right away since it's mostly for my benefit right now.