### PR TITLE
Add select modal for multi compiler stats.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -102,7 +102,15 @@ function load(stats) {
 	ga('set', 'dimension3', categorize(stats.assets.length)  + "");
 	ga('set', 'dimension4', categorize(stats.time)           + "");
 }
-exports.load = load;
+
+exports.load = function (stats) {
+	var isMultiCompile = !stats.assets && !stats.modules && stats.children && stats.children.length > 1;
+	if (isMultiCompile) {
+		exports.loadPage("select", stats);
+	} else {
+		load(stats);
+  }
+}
 
 function categorize(number) {
 	if(number <= 0) return 0;

--- a/app/entry.js
+++ b/app/entry.js
@@ -23,7 +23,7 @@ function loadPage(name) {
 	if(!name) name = "home";
 	var pageBundle;
 	var args = Array.prototype.slice.call(arguments, 1);
-	if(!app.stats) {
+	if(!app.stats && name != "select") {
 		args.unshift(name);
 		name = "upload";
 	}

--- a/app/pages/select/application.jade
+++ b/app/pages/select/application.jade
@@ -1,0 +1,22 @@
+nav.navbar.navbar-default
+	.container-fluid
+		ul.nav.navbar-nav
+			li: a(href="") Open
+			li: a(href="#home") Home
+			li: a(href="#modules") Modules
+			li: a(href="#chunks") Chunks
+			li: a(href="#assets") Assets
+			li: a(href="#warnings") Warnings
+			li: a(href="#errors") Errors
+			li: a(href="#hints") Hints
+#sigma-modules(style="width: 99%; height: 500px; display:none;")
+#sigma-chunks(style="width: 99%; height: 500px; display:none;")
+.page
+
+.modal.fade: .modal-dialog: .modal-content
+	.modal-header
+		h4.modal-title Select webpack compile
+	.modal-body
+		each val, index in children
+			button.js-select.btn.btn-primary.btn-block(data-index=index) #{val.name || ("Compile #" + (index+1))}
+	.modal-footer

--- a/app/pages/select/page.js
+++ b/app/pages/select/page.js
@@ -1,0 +1,13 @@
+var app = require("../../app");
+
+module.exports = function(stats) {
+	document.title = "select";
+	$("body").html(require("./application.jade")(stats));
+	$(".modal").modal({show: true});
+	$(".js-select").click(function () {
+		var index = $(this).data("index");
+		app.load(stats.children[index]);
+		$(".modal").modal("hide");
+		app.loadPage("home");
+  });
+};


### PR DESCRIPTION
This fixes analyzing of [multi compiler](https://github.com/webpack/webpack/tree/master/examples/multi-compiler) stats by adding a modal where you can select which target to analyze.