### PR TITLE
Open webpack documentation links in a new tab

### DIFF
--- a/app/pages/home/home.jade
+++ b/app/pages/home/home.jade
@@ -7,9 +7,9 @@
 		.col-md-3
 			.well: center
 				h1
-					a(href="http://webpack.github.io/") webpack
+					a(href="http://webpack.github.io/", target="_blank", rel="noopener noreferrer") webpack
 					br
-					a(href="http://webpack.github.io/docs/changelog.html")= stats.version
+					a(href="http://webpack.github.io/docs/changelog.html", target="_blank", rel="noopener noreferrer")= stats.version
 		.col-md-3
 			.well: center
 				h1


### PR DESCRIPTION
I found it annoying that the webpack documentation link replaced the current page. When I clicked back, the analyse app didn't remember its previous state, so I had to reupload my stats.

Prevent this by opening the documentation links in a new tab.