### PR TITLE
add dependency chain information to module page

### DIFF
--- a/app/pages/module/module.jade
+++ b/app/pages/module/module.jade
@@ -78,6 +78,28 @@
 									code= reason.loc
 	.row
 		.col-md-12: .well
+			h4 reason chain
+			p the shortest path from each chunk entry point to this module
+			each chain in reason_chains
+				p chunk 
+					a.btn.btn-info(href="#chunk/#{chain.chunk}")= chain.chunk
+					|  origin 
+					a.btn.btn-success(href="#module/#{chain.origin}")= chain.origin
+				table.table.table-condensed
+					thead
+						tr
+							th depth from origin
+							th(colspan=2) module
+					tbody
+					each reason, inx in chain.modules
+						tr
+							td= inx
+							td(style="width: 1px")
+								a.btn.btn-success(href="#module/#{reason.uid}")= reason.id
+							td: if reason.name
+								pre: code= reason.name.split("!").join("\n")								
+	.row
+		.col-md-12: .well
 			h4 dependencies
 			table.table
 				thead

--- a/app/pages/module/page.js
+++ b/app/pages/module/page.js
@@ -1,15 +1,64 @@
 var app = require("../../app");
 var modulesGraph = require("../../graphs/modules");
 
+/** general breadth first search between start and end */
+function findPathBetween(start, end, getChildren) {
+	const todo = [start];
+	const done = new Set();
+	const parent = new Map();
+
+	while(todo.length > 0) {
+		const cur = todo.shift();
+		if(cur === end) return getPath(start, end, parent);
+		for(const child of getChildren(cur)) {
+			if(done.has(child)) continue;
+			if(todo.indexOf(child) < 0) todo.push(child);
+			parent.set(child, cur);
+		}
+		done.add(cur);
+	}
+	function getPath(start, end, parent) {
+		const path = [end];
+		while(path[0] !== start) {
+			path.unshift(parent.get(path[0]));
+		}
+		return path;
+	}
+}
+
+function getReasonChains(app, id) {
+	const m = app.mapModulesUid[id];
+	const chains = [];
+	for(const chunkId of m.chunks) {
+		const chunk = app.stats.chunks[chunkId];
+		console.assert(chunk.id === chunkId);
+		for(const mo of chunk.origins) {
+			const origin = mo.moduleUid;
+			const p = findPathBetween(origin, id, function getChildren(id) {
+				const m = app.mapModulesUid[id];
+				return m.dependencies.filter(p => p.type !== "context element").map(p => p.moduleUid);
+			});
+			chains.push({
+				chunk: chunkId,
+				origin,
+				modules: (p || []).map(x => app.mapModulesUid[x])
+			})
+		}
+	}
+	return chains;
+}
+
 module.exports = function(id) {
 	id = parseInt(id, 10);
 	var m = app.mapModulesUid[id];
 	document.title = "module " + m.id;
+
 	$(".page").html(require("./module.jade")({
 		stats: app.stats,
 		id: id,
 		module: m,
-		issuer: app.mapModulesUid[m.issuerUid]
+		issuer: app.mapModulesUid[m.issuerUid],
+		reason_chains: getReasonChains(app, id)
 	}));
 	modulesGraph.show();
 	modulesGraph.setActiveModule(id);

--- a/app/pages/module/page.js
+++ b/app/pages/module/page.js
@@ -3,14 +3,16 @@ var modulesGraph = require("../../graphs/modules");
 
 /** general breadth first search between start and end */
 function findPathBetween(start, end, getChildren) {
-	const todo = [start];
-	const done = new Set();
-	const parent = new Map();
+	var todo = [start];
+	var done = new Set();
+	var parent = new Map();
 
 	while(todo.length > 0) {
-		const cur = todo.shift();
+		var cur = todo.shift();
 		if(cur === end) return getPath(start, end, parent);
-		for(const child of getChildren(cur)) {
+		var children = getChildren(cur);
+		for(var i = 0; i < children.length; i++) {
+			var child = children[i];
 			if(done.has(child)) continue;
 			if(todo.indexOf(child) < 0) todo.push(child);
 			parent.set(child, cur);
@@ -18,7 +20,7 @@ function findPathBetween(start, end, getChildren) {
 		done.add(cur);
 	}
 	function getPath(start, end, parent) {
-		const path = [end];
+		var path = [end];
 		while(path[0] !== start) {
 			path.unshift(parent.get(path[0]));
 		}
@@ -27,21 +29,23 @@ function findPathBetween(start, end, getChildren) {
 }
 
 function getReasonChains(app, id) {
-	const m = app.mapModulesUid[id];
-	const chains = [];
-	for(const chunkId of m.chunks) {
-		const chunk = app.stats.chunks[chunkId];
+	var m = app.mapModulesUid[id];
+	var chains = [];
+	for(var i = 0; i < m.chunks.length; i++) {
+		var chunkId = m.chunks[i];
+		var chunk = app.stats.chunks[chunkId];
 		console.assert(chunk.id === chunkId);
-		for(const mo of chunk.origins) {
-			const origin = mo.moduleUid;
-			const p = findPathBetween(origin, id, function getChildren(id) {
-				const m = app.mapModulesUid[id];
-				return m.dependencies.filter(p => p.type !== "context element").map(p => p.moduleUid);
+		for(var j = 0; j < chunk.origins.length; j++) {
+			var mo = chunk.origins[j];
+			var origin = mo.moduleUid;
+			var p = findPathBetween(origin, id, function getChildren(id) {
+				var m = app.mapModulesUid[id];
+				return m.dependencies.filter(function(p) {return p.type !== "context element"}).map(function(p) {return p.moduleUid});
 			});
 			chains.push({
 				chunk: chunkId,
-				origin,
-				modules: (p || []).map(x => app.mapModulesUid[x])
+				origin: origin,
+				modules: (p || []).map(function(x) {return app.mapModulesUid[x]})
 			})
 		}
 	}


### PR DESCRIPTION
This PR adds functionality to show _why_ a specific module is included in a specific chunk by showing the dependency chain from the entry module of the chunk to the current module. This is really useful for deeper chains where the "reasons" field is not really helpful.

Screenshot:

![image](https://user-images.githubusercontent.com/2303841/36795890-756fce74-1ca4-11e8-9c8c-27f476bd3722.png)
