### PR TITLE
fix: cannot read property 'sort' of undefined

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,6 +7,8 @@ function load(stats) {
 	stats.assets.sort(function(a, b) {
 		return b.size - a.size;
 	});
+
+	stats.modules = stats.modules || [];
 	stats.modules.sort(function(a, b) {
 		return a.id - b.id;
 	});


### PR DESCRIPTION
When using Angular CLI to generate the stats, and upload it I am getting `cannot read property 'sort' of undefined` This is due, when using lazy loading, there are no modules, but rather chunks.