### PR TITLE
Fix the template for the hints page

### DIFF
--- a/app/pages/hints/hints.pug
+++ b/app/pages/hints/hints.pug
@@ -22,8 +22,7 @@
 										a.btn.btn-success(href=`#module/${item.module.uid}`)= item.module.id
 									else
 										span.btn.btn-success= item.module.id
-								splittedModule = item.module.name.split("!")
-								td: pre: code= splittedModule.join("\n")
+								td: pre: code= item.module.name.split("!").join("\n")
 								td= item.count
 								td
 									for chunk, idx in item.module.chunks


### PR DESCRIPTION
The old code was rendering a `<splittedModule>` HTML tag, not defining a variable. And this broke then when trying to use the `splittedModule` variable as it would be undefined.

An alternative fix would have been to define the variable using `- var splittedModule = item.module.name.split("!")`. but as the variable was used only once, I removed it (which is consistent with other places doing such split in the file)