### PR TITLE
Fix wrong URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # analyse
 
-[http://webpack.github.com/analyse](http://webpack.github.com/analyse)
+[https://webpack.github.io/analyse](https://webpack.github.io/analyse)
 
 ## Running
 


### PR DESCRIPTION
`http://webpack.github.com/` was used while `https://webpack.github.io/` is the correct one.