### PR TITLE
Updated link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # analyse
 
-[http://webpack.github.com/analyse](http://webpack.github.com/analyse)
+[http://webpack.github.io/analyse](http://webpack.github.io/analyse)
 
 ## Running
 


### PR DESCRIPTION
Subdomains of github.com are deprecated for GitHub Pages

Updated the link from https://webpack.github.com/analyse to https://webpack.github.io/analyse/