### PR TITLE
Updated link in readme to reflect correct website (TLD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # analyse
 
-[http://webpack.github.com/analyse](http://webpack.github.com/analyse)
+[http://webpack.github.io/analyse](http://webpack.github.io/analyse)
 
 ## Running
 


### PR DESCRIPTION
The link had an old TLD (.com), so it was resulting in a 404. I simply updated it to the correct TLD.