### PR TITLE
docs: fix github pages link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # analyse
 
-[http://webpack.github.com/analyse](http://webpack.github.com/analyse)
+[https://webpack.github.io/analyse](https://webpack.github.io/analyse)
 
 ## Running
 


### PR DESCRIPTION
Should the GitHub pages link in the README point to `github.io` instead of `github.com`? And also be HTTPS.
E.g., https://webpack.github.io/analyse instead of http://webpack.github.com/analyse

A maintainer/admin could also update the website link in the repository metadata.
