### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # analyse
 
-[http://webpack.github.com/analyse](http://webpack.github.com/analyse)
+[http://webpack.github.io/analyse](http://webpack.github.io/analyse)
 
 ## Running
 


### PR DESCRIPTION
The link in the readme has 404'd for a long time. I find this tool very useful and hope that we can get the readme updated along with the URL in the repo description.